### PR TITLE
feat: symlink fleek config from flake home

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -3,6 +3,7 @@ package core
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -133,6 +134,15 @@ func WriteSampleConfig(email, name string, force bool) error {
 		// convert to string to get `-` style lists
 		sbb := string(n)
 		_, err = cfg.WriteString(sbb)
+		if err != nil {
+			return err
+		}
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
+		csym := filepath.Join(home, ".fleek.yml")
+		err = os.Symlink(cfile, csym)
 		if err != nil {
 			return err
 		}

--- a/core/fleek.go
+++ b/core/fleek.go
@@ -8,11 +8,11 @@ import (
 // ConfigLocation returns the path for the
 // fleek configuration file.
 func ConfigLocation() (string, error) {
-	home, err := os.UserHomeDir()
+	hm, err := FlakeLocation()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, ".fleek.yml"), nil
+	return filepath.Join(hm, ".fleek.yml"), nil
 }
 
 // FlakeLocation returns the path where the


### PR DESCRIPTION
This change moves the fleek configuration file into the home-manager config for future git management and symlinks back to $HOME