### PR TITLE
feat: ejection

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -34,23 +34,28 @@ func apply(cmd *cobra.Command, args []string) {
 	if verbose {
 		cmdr.Info.Println(fleek.Trans("apply.writingConfig"))
 	}
-	err := core.WriteFlake()
-	cobra.CheckErr(err)
-	if verbose {
-		cmdr.Info.Println(fleek.Trans("apply.writingFlake"))
+	// only re-apply the templates if not `ejected`
+	if ejected, _ := core.Ejected(); !ejected {
+		if verbose {
+			cmdr.Info.Println(fleek.Trans("apply.writingFlake"))
+		}
+		err := core.WriteFlake()
+		cobra.CheckErr(err)
+
 	}
-	err = core.CheckFlake()
-	cobra.CheckErr(err)
+
 	var dry bool
 	if cmd.Flag("dry-run").Changed {
 		dry = true
 	}
 	if !dry {
 		cmdr.Info.Println(fleek.Trans("apply.applyingConfig"))
-		err = core.ApplyFlake()
+		err := core.ApplyFlake()
 		cobra.CheckErr(err)
 	} else {
 		cmdr.Info.Println(fleek.Trans("apply.dryApplyingConfig"))
+		err := core.CheckFlake()
+		cobra.CheckErr(err)
 	}
 	cmdr.Success.Println(fleek.Trans("apply.done"))
 

--- a/cmd/eject.go
+++ b/cmd/eject.go
@@ -1,0 +1,37 @@
+/*
+Copyright © 2023 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/ublue-os/fleek/core"
+	"github.com/vanilla-os/orchid/cmdr"
+)
+
+func NewEjectCommand() *cmdr.Command {
+	cmd := cmdr.NewCommandRun(
+		fleek.Trans("eject.use"),
+		fleek.Trans("eject.long"),
+		fleek.Trans("eject.short"),
+		eject,
+	)
+	return cmd
+}
+
+// initCmd represents the init command
+func eject(cmd *cobra.Command, args []string) {
+
+	ok, err := cmdr.Confirm.Show(fleek.Trans("eject.confirm"))
+	cobra.CheckErr(err)
+
+	if ok {
+		cmdr.Info.Println(fleek.Trans("eject.start"))
+		err := core.WriteFlake()
+		cobra.CheckErr(err)
+		err = core.WriteEjectConfig()
+		cobra.CheckErr(err)
+		cmdr.Info.Println(fleek.Trans("eject.complete"))
+	}
+
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"embed"
+	"os"
 
+	"github.com/spf13/cobra"
+	"github.com/ublue-os/fleek/core"
 	"github.com/vanilla-os/orchid/cmdr"
 )
 
@@ -30,5 +33,12 @@ func NewRootCommand(version string) *cmdr.Command {
 				false))
 
 	root.Version = version
+	root.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		ok := core.CheckNix()
+		if !ok {
+			cmdr.Error.Println(fleek.Trans("fleek.installNix"))
+			os.Exit(1)
+		}
+	}
 	return root
 }

--- a/core/checks.go
+++ b/core/checks.go
@@ -1,10 +1,12 @@
 package core
 
-import "fmt"
+import (
+	"os/exec"
+)
 
 // CheckNix verifies that the nix
 // command is available in user's PATH
 func CheckNix() bool {
-	fmt.Println("TODO: check for nix binary, configs here")
-	return true
+	_, err := exec.LookPath("nix")
+	return err == nil
 }

--- a/core/config.go
+++ b/core/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	Aliases    map[string]string `yaml:",flow"`
 	Paths      []string          `yaml:"paths"`
 	Me         Me                `yaml:"me"`
+	Ejected    bool              `yaml:"ejected"`
 }
 type Me struct {
 	Name  string `yaml:"name"`
@@ -68,6 +69,7 @@ func ReadConfig() (*Config, error) {
 	if err != nil {
 		return c, err
 	}
+
 	bb, err := os.ReadFile(cfile)
 	if err != nil {
 		return c, err
@@ -77,6 +79,14 @@ func ReadConfig() (*Config, error) {
 		return c, err
 	}
 	return c, nil
+}
+
+func Ejected() (bool, error) {
+	conf, err := ReadConfig()
+	if err != nil {
+		return false, err
+	}
+	return conf.Ejected, nil
 }
 
 // WriteSampleConfig creates the first fleek
@@ -149,5 +159,39 @@ func WriteSampleConfig(email, name string, force bool) error {
 	} else {
 		return errors.New("cowardly refusing to overwrite config file without --force flag")
 	}
+	return nil
+}
+
+// WriteEjectConfig updates the .fleek.yml file
+// to indicated ejected status
+func WriteEjectConfig() error {
+
+	c := Config{
+		Ejected: true,
+	}
+	cfile, err := ConfigLocation()
+	if err != nil {
+		return err
+	}
+
+	bb, err := yaml.Marshal(&c)
+	if err != nil {
+		return err
+	}
+	m := make(map[interface{}]interface{})
+	err = yaml.Unmarshal(bb, &m)
+	if err != nil {
+		return err
+	}
+	n, err := yaml.Marshal(&m)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(cfile, n, 0755)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/core/home.nix.tmpl
+++ b/core/home.nix.tmpl
@@ -12,8 +12,11 @@
   };
   home.username = "{{.UserName}}";
   home.homeDirectory = "{{.Home}}";
+  {{ if not .Config.Ejected }}
   # managed by fleek, modify ~/.fleek.yml to change installed packages
-  # packages are just installed
+  {{ end }}
+  # packages are just installed (no configuration applied)
+  # programs are installed and configuration applied to dotfiles
   home.packages = [{{ range .Config.Packages }}
     pkgs.{{ . }}{{ end }}
     {{ range .LowPackages }}

--- a/core/programs.nix.tmpl
+++ b/core/programs.nix.tmpl
@@ -1,7 +1,7 @@
 { pkgs, misc, ... }: {
- 
-  # programs are installed and configured.
-  # add your program configuration in ./user.nix{{ range .Config.Programs }}
+  # packages are just installed (no configuration applied)
+  # programs are installed and configuration applied to dotfiles
+  # add your personalized program configuration in ./user.nix{{ range .Config.Programs }}
     programs.{{ . }}.enable = true;{{ end }}
     # low bling
     {{ range .LowPrograms }}

--- a/core/user.nix.tmpl
+++ b/core/user.nix.tmpl
@@ -1,7 +1,8 @@
 { pkgs, misc, ... }: {
     # This file will never be modified by fleek
+    {{ if not .Config.Ejected }}
     # configs mentioned here must be listed in ~/fleek.yml #programs array or you will get errors
-
+    {{ end }}
 
  
 }

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -3,7 +3,16 @@ fleek:
   long: "Fleek installs and manages packages in your nix installation with a \nfriendly and approachable config file."
   short: "Fleek makes nix friendly"
   verboseFlag: "show more detailed output"
+  installNix: "No nix installation found! We recommend starting at https://zero-to-nix.com/"
 
+eject:
+  use: "eject"
+  long: "Eject writes your current configuration to disk and removes Fleek's templates.\n\nChanges to .fleek.yml will be ignored; you will modify your Nix configurations directly."
+  short: "Manage your home configuration directly, without the .fleek.yml file."
+  verboseFlag: "show more detailed output"
+  start: "Applying current fleek configuration to your home flake."
+  complete: "Home configuration written. All changes should now be made in ~/.config/home-manager/ directly."
+  confirm: "Are you sure you want to manage your home configuration files directly?"
 apply:
   use: "apply"
   long: "Apply fleek profile by reading the ~/.fleek.yml file and updating \nthe flake templates."

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	Version = "1.7.0-1"
+	Version = "42"
 )
 
 //go:embed locales/*.yml
@@ -18,9 +18,7 @@ var fleek *cmdr.App
 func main() {
 	fleek = cmd.New(Version, fs)
 
-	// root command
 	root := cmd.NewRootCommand(Version)
-	// root command
 	fleek.CreateRootCommand(root)
 
 	apply := cmd.NewApplyCommand()
@@ -28,47 +26,11 @@ func main() {
 
 	init := cmd.NewInitCommand()
 	root.AddCommand(init)
-	/*
-		enter := cmd.NewEnterCommand()
-		root.AddCommand(cmd.AddContainerFlags(enter))
 
-		export := cmd.NewExportCommand()
-		root.AddCommand(cmd.AddContainerFlags(export))
+	eject := cmd.NewEjectCommand()
+	root.AddCommand(eject)
 
-		initialize := cmd.NewInitializeCommand()
-		root.AddCommand(cmd.AddContainerFlags(initialize))
-
-		install := cmd.NewInstallCommand()
-		root.AddCommand(cmd.AddContainerFlags(install))
-
-		list := cmd.NewListCommand()
-		root.AddCommand(cmd.AddContainerFlags(list))
-
-		purge := cmd.NewPurgeCommand()
-		root.AddCommand(cmd.AddContainerFlags(purge))
-
-		remove := cmd.NewRemoveCommand()
-		root.AddCommand(cmd.AddContainerFlags(remove))
-
-		run := cmd.NewRunCommand()
-		root.AddCommand(cmd.AddContainerFlags(run))
-
-		search := cmd.NewSearchCommand()
-		root.AddCommand(cmd.AddContainerFlags(search))
-
-		show := cmd.NewShowCommand()
-		root.AddCommand(cmd.AddContainerFlags(show))
-
-		unexport := cmd.NewUnexportCommand()
-		root.AddCommand(cmd.AddContainerFlags(unexport))
-
-		upgrade := cmd.NewUpgradeCommand()
-		root.AddCommand(cmd.AddContainerFlags(upgrade))
-
-		update := cmd.NewUpdateCommand()
-		root.AddCommand(cmd.AddContainerFlags(update))
-		// run the app
-	*/
+	// run the app
 	err := fleek.Run()
 	if err != nil {
 		cmdr.Error.Println(err)


### PR DESCRIPTION
This change allows `ejection` from Fleek's yaml management. Once ejected, templates are never modified by fleek, and the user assumes ownership of the flake. Other fleek functionality (esp. `apply` continues to work)