### PR TITLE
feat: display warning about mismatch in configured vs login shells

### DIFF
--- a/cmd/fleek.go
+++ b/cmd/fleek.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 
 	"io/fs"
@@ -229,5 +230,17 @@ func (f *fleek) Repo() (*git.FlakeRepo, error) {
 func (f *fleek) Sanity() ([]string, error) {
 	// check nix
 	// check flakes
-	return []string{}, nil
+	msgs := []string{}
+	shell, err := core.UserShell()
+	if err != nil {
+		return []string{}, err
+	}
+	configuredShell := f.config.Shell
+	if shell != configuredShell {
+		msgs = append(msgs, "----Configuration Mismatch----")
+		msgs = append(msgs, fmt.Sprintf("~/.fleek.yml configured shell is %s, but user configured shell is %s", configuredShell, shell))
+		msgs = append(msgs, "Consult your operating system documentation on how to change your login shell")
+
+	}
+	return msgs, nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -120,6 +120,11 @@ func NewRootCommand(version string) *cmdr.Command {
 			cobra.CheckErr(err)
 
 		}
+		msgs, err := f.Sanity()
+		cobra.CheckErr(err)
+		for _, msg := range msgs {
+			cmdr.Warning.Println("System Check:", msg)
+		}
 		/*
 			repo = git.NewFlakeRepo(flakeLocation)
 

--- a/core/system.go
+++ b/core/system.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"os/user"
 )
@@ -73,4 +74,39 @@ func CurrentSystem() (*System, error) {
 		}
 	}
 	return nil, ErrSysNotFound
+}
+
+func UserShell() (string, error) {
+	// modified from https://github.com/captainsafia/go-user-shell/blob/master/user_shell.go
+	// MIT License
+	// Copyright (c) 2017 Safia Abdalla
+	var shell string
+	switch runtime.GOOS {
+	case "windows":
+		if os.Getenv("COMSPEC") != "" {
+			shell = os.Getenv("COMSPEC")
+		} else {
+			shell = "/cmd.exe"
+		}
+	case "darwin":
+		if os.Getenv("SHELL") != "" {
+			shell = os.Getenv("SHELL")
+		} else {
+			shell = "/bin/zsh"
+		}
+	default:
+		if os.Getenv("SHELL") != "" {
+			shell = os.Getenv("SHELL")
+		} else {
+			shell = "/bin/sh"
+		}
+	}
+	if strings.Contains(shell, "zsh") {
+		shell = "zsh"
+	}
+	if strings.Contains(shell, "bash") {
+		shell = "bash"
+	}
+	return shell, nil
+
 }


### PR DESCRIPTION
if .fleek.yml contains a shell: line that doesn't match the user's login shell, display a warning at the end of a fleek command run.