### PR TITLE
fix: create git config when cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ I spent the next two weeks tweaking the user experience and testing over and ove
 
 And now we're here. `fleek` is ready for a broader audience than me and Jorge - who is the biggest inspriation for all the features `fleek` has, and maybe just as importantly, doesn't have.
 
+
 ## Shoulders
 
 Standing on the shoulders of giants:

--- a/internal/fleekcli/add.go
+++ b/internal/fleekcli/add.go
@@ -4,8 +4,11 @@ Copyright © 2023 NAME HERE <EMAIL ADDRESS>
 package fleekcli
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 	"github.com/ublue-os/fleek/internal/debug"
+	"github.com/ublue-os/fleek/internal/nix"
 	"github.com/ublue-os/fleek/internal/ux"
 )
 
@@ -85,7 +88,12 @@ func add(cmd *cobra.Command, args []string) error {
 		}
 		out, err = flake.Apply()
 		if err != nil {
-			debug.Log("flake apply error: %s", err)
+			ux.Error.Println(string(out))
+
+			if errors.Is(err, nix.ErrPackageConflict) {
+				ux.Fatal.Println(app.Trans("global.errConflict"))
+			}
+
 			return err
 		}
 		if verbose {

--- a/internal/fleekcli/apply.go
+++ b/internal/fleekcli/apply.go
@@ -4,8 +4,11 @@ Copyright © 2023 NAME HERE <EMAIL ADDRESS>
 package fleekcli
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 	"github.com/ublue-os/fleek/internal/debug"
+	"github.com/ublue-os/fleek/internal/nix"
 	"github.com/ublue-os/fleek/internal/ux"
 )
 
@@ -92,7 +95,12 @@ func apply(cmd *cobra.Command, args []string) error {
 		}
 		out, err := flake.Apply()
 		if err != nil {
-			debug.Log("flake apply error: %s", err)
+			ux.Error.Println(string(out))
+
+			if errors.Is(err, nix.ErrPackageConflict) {
+				ux.Fatal.Println(app.Trans("global.errConflict"))
+			}
+
 			return err
 		}
 		if verbose {

--- a/internal/fleekcli/remove.go
+++ b/internal/fleekcli/remove.go
@@ -4,8 +4,11 @@ Copyright © 2023 NAME HERE <EMAIL ADDRESS>
 package fleekcli
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 	"github.com/ublue-os/fleek/internal/debug"
+	"github.com/ublue-os/fleek/internal/nix"
 	"github.com/ublue-os/fleek/internal/ux"
 )
 
@@ -101,7 +104,12 @@ func remove(cmd *cobra.Command, args []string) error {
 		out, err = flake.Apply()
 		if err != nil {
 			spinner.Fail()
-			debug.Log("flake apply error: %s", err)
+			ux.Error.Println(string(out))
+
+			if errors.Is(err, nix.ErrPackageConflict) {
+				ux.Fatal.Println(app.Trans("global.errConflict"))
+			}
+
 			return err
 		}
 		spinner.Success()

--- a/internal/fleekcli/update.go
+++ b/internal/fleekcli/update.go
@@ -4,8 +4,11 @@ Copyright © 2023 NAME HERE <EMAIL ADDRESS>
 package fleekcli
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 	"github.com/ublue-os/fleek/internal/debug"
+	"github.com/ublue-os/fleek/internal/nix"
 	"github.com/ublue-os/fleek/internal/ux"
 )
 
@@ -64,7 +67,12 @@ func update(cmd *cobra.Command, args []string) error {
 		out, err := flake.Apply()
 		if err != nil {
 			spinner.Fail()
-			debug.Log("flake apply error: %s", err)
+			ux.Error.Println(string(out))
+
+			if errors.Is(err, nix.ErrPackageConflict) {
+				ux.Fatal.Println(app.Trans("global.errConflict"))
+			}
+
 			return err
 		}
 		if verbose {

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -171,5 +171,6 @@ global:
   fleekGroup: "Configuration Commands"
   packageGroup: "Package Management Commands"
   gitGroup: "Repository Management Commands"
+  errConflict: "A package in your .fleek.yml exists in your nix profile.\nThis can happen if you manually install something with `nix profile install ...`.\nTo fix this error, run `nix profile list` and find the profile number of the offending package, then run `nix profile remomve [that number]`\nbefore running `fleek` again."
 
   


### PR DESCRIPTION
fixes #78 
Also displays a better error when a package is manually installed with `nix profile install`, and the flake contains the same package.