### PR TITLE
fix: flake lock error with home-manager

### DIFF
--- a/internal/flake/flake.go
+++ b/internal/flake/flake.go
@@ -445,7 +445,7 @@ func (f *Flake) Apply() error {
 	if err != nil {
 		return err
 	}
-	applyCmdLine := []string{"run", "--impure", "home-manager/master", "--", "-b", "bak", "switch", "--flake", ".#" + user + "@" + host}
+	applyCmdLine := []string{"run", "--no-write-lock-file", "--impure", "home-manager/master", "--", "-b", "bak", "switch", "--flake", ".#" + user + "@" + host}
 	out, err := f.runNix(nixbin, applyCmdLine)
 	if err != nil {
 		if bytes.Contains(out, []byte("priority")) {


### PR DESCRIPTION
fixes #141 - adds -no-write-lock-file to flake run