### PR TITLE
docs: script link goes to my script in new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Fleek is a user-friendly wrapper around Nix and Nix Home Manager, but the friend
 
 ## Getting Started
 
-You need `nix`. We love the [Determinate Systems Installer](https://zero-to-nix.com/), but any `nix` is good. If you're on Fedora Silverblue [this script](https://github.com/dnkmmr69420/nix-with-selinux/blob/main/silverblue-installer.sh) is the good stuff.
+You need `nix`. We love the [Determinate Systems Installer](https://zero-to-nix.com/), but any `nix` is good. If you're on Fedora Silverblue [this script](https://github.com/dnkmmr69420/nix-installer-scripts/blob/main/installer-scripts/silverblue-nix-installer.sh) is the good stuff.
 
 After Nix is installed you need to enable [flakes and the nix command](https://nixos.wiki/wiki/Flakes). It can be as simple as this:
 


### PR DESCRIPTION
The link goes to my old archived repo and it will no longer be updated. Now the link goes to my new repo. I created a repo and migrated all of my nix stuff to one repo so it is easier to manage.