### PR TITLE
docs: fix README template formatting

### DIFF
--- a/internal/flake/templates/README.md.tmpl
+++ b/internal/flake/templates/README.md.tmpl
@@ -1,10 +1,11 @@
 # {{.Config.Name}}
+
 nix home-manager configs created by [fleek](https://github.com/ublue-os/fleek)
 
 ## Reference
 
-[home-manager](https://nix-community.github.io/home-manager/)
-[home-manager options](https://nix-community.github.io/home-manager/options.html)
+- [home-manager](https://nix-community.github.io/home-manager/)
+- [home-manager options](https://nix-community.github.io/home-manager/options.html)
 
 ## Usage
 
@@ -18,6 +19,7 @@ $ apply-{hostname}
 ```
 
 Your actual aliases are listed below:
+
 {{- range $index, $element := .Config.Aliases }}
     {{$index}} = "{{$element}}";
 {{ end -}}

--- a/internal/flake/templates/README.md.tmpl
+++ b/internal/flake/templates/README.md.tmpl
@@ -1,6 +1,6 @@
 # {{.Config.Name}}
 
-nix home-manager configs created by [fleek](https://github.com/ublue-os/fleek)
+nix home-manager configs created by [fleek](https://github.com/ublue-os/fleek).
 
 ## Reference
 
@@ -15,7 +15,7 @@ Aliases were added to the config to make it easier to use. To use them, run the 
 # To change into the fleek generated home-manager directory
 $ fleeks
 # To apply the configuration
-$ apply-{hostname}
+$ apply-$(hostname)
 ```
 
 Your actual aliases are listed below:


### PR DESCRIPTION
Fixed formatting of aliases flowing into the previous line and switched the links to a list.