### PR TITLE
Add support for defining overlays in YAML

### DIFF
--- a/internal/flake/templates/flake.nix.tmpl
+++ b/internal/flake/templates/flake.nix.tmpl
@@ -13,18 +13,24 @@
     # Fleek
     fleek.url = "github:ublue-os/fleek";
 
+    # Overlays
+    {{ range $index, $element := .Config.Overlays }}
+    {{$index}}.url = "{{$element.Url}}";
+    {{ if $element.Follow }}{{$index}}.inputs.nixpkgs.follows = "nixpkgs";{{end}}
+    {{ end }}
+
   };
 
-  outputs = { nixpkgs, home-manager, fleek, ... }@inputs: {
+  outputs = { self, nixpkgs, home-manager, fleek, ... }@inputs: {
 
     # Available through 'home-manager --flake .#your-username@your-hostname'
+    {{ $overlays := .Config.Overlays  }}
     homeConfigurations = {
     {{ range .Config.Systems }}
       "{{ .Username }}@{{ .Hostname }}" = home-manager.lib.homeManagerConfiguration {
         pkgs = nixpkgs.legacyPackages.{{ .Arch }}-{{ .OS }}; # Home-manager requires 'pkgs' instance
         extraSpecialArgs = { inherit inputs; }; # Pass flake inputs to our config
-
-        modules = [ 
+        modules = [
           ./home.nix 
           ./path.nix
           ./shell.nix
@@ -35,11 +41,12 @@
           ./{{.Hostname}}/{{.Hostname}}.nix
           ./{{.Hostname}}/user.nix
           # self-manage fleek
-          {
+          ({
+           nixpkgs.overlays = [{{ range $index, $element := $overlays }}inputs.{{$index}}.overlay {{ end }}];
            home.packages = [
             fleek.packages.{{ .Arch }}-{{ .OS }}.default
           ];
-          }
+          })
 
         ];
       };

--- a/internal/fleek/config.go
+++ b/internal/fleek/config.go
@@ -41,16 +41,17 @@ type Config struct {
 	// bash or zsh
 	Shell string `yaml:"shell"`
 	// low, default, high
-	Bling    string            `yaml:"bling"`
-	Name     string            `yaml:"name"`
-	Packages []string          `yaml:",flow"`
-	Programs []string          `yaml:",flow"`
-	Aliases  map[string]string `yaml:",flow"`
-	Paths    []string          `yaml:"paths"`
-	Ejected  bool              `yaml:"ejected"`
-	Systems  []*System         `yaml:",flow"`
-	Git      Git               `yaml:"git"`
-	Users    []*User           `yaml:",flow"`
+	Bling    string              `yaml:"bling"`
+	Name     string              `yaml:"name"`
+	Overlays map[string]*Overlay `yaml:",flow"`
+	Packages []string            `yaml:",flow"`
+	Programs []string            `yaml:",flow"`
+	Aliases  map[string]string   `yaml:",flow"`
+	Paths    []string            `yaml:"paths"`
+	Ejected  bool                `yaml:"ejected"`
+	Systems  []*System           `yaml:",flow"`
+	Git      Git                 `yaml:"git"`
+	Users    []*User             `yaml:",flow"`
 }
 
 func Levels() []string {
@@ -77,6 +78,11 @@ type User struct {
 	Email             string `yaml:"email"`
 	SSHPublicKeyFile  string `yaml:"ssh_public_key_file"`
 	SSHPrivateKeyFile string `yaml:"ssh_private_key_file"`
+}
+
+type Overlay struct {
+	Url    string `yaml:"url"`
+	Follow bool   `yaml:"follow"`
 }
 
 func (s System) HomeDir() string {


### PR DESCRIPTION
This allows users to add an `overlays` section in the .fleek.yml, which is then fed into the homeConfigurations for use in packages and user.nix. The motivating use case was being able to use the emacs overlay, which grants access to both more recent versions of emacs as well as the contents of ELPA and MELPA.

To add overlays, you add something like the following to `.fleek.yml`:

```yaml
overlays:
    emacs:
        url: github:nix-community/emacs-overlay
        follow: true
    nur:
        url: github:nix-community/NUR
        follow: false
```
Once that's there, you can reference the overlays in `user.nix` -- for example, to grab the GTK build of emacs and a theme, you'd add the following to `user.nix`:

```nix
   programs.emacs = {
     package = pkgs.emacsPgtk;
     extraPackages = epkgs:
       with epkgs; [
         base16-theme
       ];
   };
```
