### PR TITLE
fix double prepend $HOME when reading .fleek.yml

### DIFF
--- a/internal/fleek/config.go
+++ b/internal/fleek/config.go
@@ -410,7 +410,11 @@ func ReadConfig(loc string) (*Config, error) {
 		csym := filepath.Join(home, ".fleek.yml")
 		loc = csym
 	} else {
-		loc = filepath.Join(home, loc, ".fleek.yml")
+		if strings.HasPrefix(loc, home) {
+			loc = filepath.Join(loc, ".fleek.yml")
+		} else {
+			loc = filepath.Join(home, loc, ".fleek.yml")
+		}
 	}
 	bb, err := os.ReadFile(loc)
 	if err != nil {


### PR DESCRIPTION
this fixes #221 for me -- not really familiar with go or any of its tooling, apologies if formatting is off