### PR TITLE
fix: remove default wrapping location with home dir in config.go

### DIFF
--- a/internal/fleek/config.go
+++ b/internal/fleek/config.go
@@ -406,15 +406,10 @@ func ReadConfig(loc string) (*Config, error) {
 		return c, err
 	}
 	if loc == "" {
-
 		csym := filepath.Join(home, ".fleek.yml")
 		loc = csym
 	} else {
-		if strings.HasPrefix(loc, home) {
-			loc = filepath.Join(loc, ".fleek.yml")
-		} else {
-			loc = filepath.Join(home, loc, ".fleek.yml")
-		}
+		loc = filepath.Join(loc, ".fleek.yml")
 	}
 	bb, err := os.ReadFile(loc)
 	if err != nil {


### PR DESCRIPTION
This fixes #228 , although it may break a call in L49 - internal/fleekcli/root.go/RootCmd(), I can't test it right now