### PR TITLE
feat: specify home in system config

### DIFF
--- a/internal/fleek/config.go
+++ b/internal/fleek/config.go
@@ -77,6 +77,7 @@ type System struct {
 	Username string `yaml:"username"`
 	Arch     string `yaml:"arch"`
 	OS       string `yaml:"os"`
+	Home     string `yaml:"home"`
 }
 
 type User struct {
@@ -93,6 +94,9 @@ type Overlay struct {
 }
 
 func (u User) HomeDir(s System) string {
+	if s.Home != "" {
+		return s.Home
+	}
 	base := "/home"
 	if s.OS == "darwin" {
 		base = "/Users"


### PR DESCRIPTION
if the `systems` block specifies a `home` key, it will be used as the HOME location for a user.
