### PR TITLE
Help when nix list responds in error

### DIFF
--- a/internal/fleekcli/root.go
+++ b/internal/fleekcli/root.go
@@ -43,6 +43,7 @@ func RootCmd() *cobra.Command {
 
 			err := flake.ForceProfile()
 			if err != nil {
+				fin.Error.Println("Nix can't list profiles.")
 				os.Exit(1)
 			}
 			// try to get the config, which may not exist yet


### PR DESCRIPTION
Not having this means users see a blank output on most commands with no way to identify why.


I mangled my nix installation, being new to nix. `nix list profiles` was returning an error due to a file being empty.

Fleek stopped responding to commands and I traced it to this. Instead of exiting, we should warn in some want to check on the nix installation. 

I'm not sure what the best message would be and defer to a nix knower.