### PR TITLE
fix: add XCURSOR_PATH

### DIFF
--- a/internal/flake/templates/shell.nix.tmpl
+++ b/internal/flake/templates/shell.nix.tmpl
@@ -12,7 +12,11 @@
     {{ end -}}
 # {{ .Config.Shell }}
 {{- if eq .Config.Shell "bash" }}
-  programs.bash.profileExtra = "[ -r ~/.nix-profile/etc/profile.d/nix.sh ] && source  ~/.nix-profile/etc/profile.d/nix.sh";
+  programs.bash.profileExtra = ''
+    [ -r ~/.nix-profile/etc/profile.d/nix.sh ] && source  ~/.nix-profile/etc/profile.d/nix.sh
+    export XCURSOR_PATH=~/.icons:~/.nix-profile/share/icons/:$XCURSOR_PATH
+
+  '';
   programs.bash.initExtra = ''
     if [ -f /etc/bashrc ]; then
         . /etc/bashrc
@@ -24,7 +28,10 @@
   programs.bash.enable = true;
 {{ end -}}
 {{- if eq .Config.Shell "zsh" }}
-  programs.zsh.profileExtra = "[ -r ~/.nix-profile/etc/profile.d/nix.sh ] && source  ~/.nix-profile/etc/profile.d/nix.sh";
+  programs.zsh.profileExtra = ''
+    [ -r ~/.nix-profile/etc/profile.d/nix.sh ] && source  ~/.nix-profile/etc/profile.d/nix.sh
+    export XCURSOR_PATH=~/.icons:~/.nix-profile/share/icons/:$XCURSOR_PATH
+  '';
   programs.zsh.enableCompletion = true;
   programs.zsh.enable = true;
 {{ end -}}


### PR DESCRIPTION
adds .nix-profile to XCURSOR_PATH to make things look good in QT/KDE environments.