### PR TITLE
fix: add default path to XCURSOR_PATH

### DIFF
--- a/internal/flake/templates/shell.nix.tmpl
+++ b/internal/flake/templates/shell.nix.tmpl
@@ -14,7 +14,7 @@
 {{- if eq .Config.Shell "bash" }}
   programs.bash.profileExtra = ''
     [ -r ~/.nix-profile/etc/profile.d/nix.sh ] && source  ~/.nix-profile/etc/profile.d/nix.sh
-    export XCURSOR_PATH=~/.icons:~/.nix-profile/share/icons/:$XCURSOR_PATH
+    export XCURSOR_PATH=$XCURSOR_PATH:/usr/share/icons:~/.local/share/icons:~/.icons:~/.nix-profile/share/icons
 
   '';
   programs.bash.initExtra = ''
@@ -30,7 +30,7 @@
 {{- if eq .Config.Shell "zsh" }}
   programs.zsh.profileExtra = ''
     [ -r ~/.nix-profile/etc/profile.d/nix.sh ] && source  ~/.nix-profile/etc/profile.d/nix.sh
-    export XCURSOR_PATH=~/.icons:~/.nix-profile/share/icons/:$XCURSOR_PATH
+    export XCURSOR_PATH=$XCURSOR_PATH:/usr/share/icons:~/.local/share/icons:~/.icons:~/.nix-profile/share/icons
   '';
   programs.zsh.enableCompletion = true;
   programs.zsh.enable = true;


### PR DESCRIPTION
Adds the default XCURSOR_PATH which is typically unset. Fixes bug reported in Discord