### PR TITLE
fix: replace exa with eza

### DIFF
--- a/internal/fleek/config.go
+++ b/internal/fleek/config.go
@@ -26,7 +26,7 @@ var (
 	HighPackages     = []string{"lazygit", "jq", "yq", "neovim", "neofetch", "btop", "cheat"}
 	LowPrograms      = []string{"starship"}
 	DefaultPrograms  = []string{"direnv"}
-	HighPrograms     = []string{"exa", "bat", "atuin", "zoxide"}
+	HighPrograms     = []string{"eza", "bat", "atuin", "zoxide"}
 )
 
 // Config holds the options that will be

--- a/internal/fleek/programs.yml
+++ b/internal/fleek/programs.yml
@@ -33,14 +33,14 @@
       Atuin replaces your existing shell history with a SQLite database, and records additional context for your commands. Additionally, it provides optional and fully encrypted synchronisation of your history between machines, via an Atuin server.
       Tip: toggle between directory, global and host history with CTRL-R
       https://atuin.sh
-  - name: exa
+  - name: eza
     description: | 
       A modern replacement for ‘ls’.
       https://the.exa.website/
     config_lines:
-      - key: programs.exa.enableAliases
+      - key: programs.eza.enableAliases
         value:  true
-      - key: programs.exa.extraOptions
+      - key: programs.eza.extraOptions
         value:  |-
          [
             "--group-directories-first"


### PR DESCRIPTION
replaces 'exa' with 'eza'. Still may require manual update of programs.nix.