### PR TITLE
feat: use environment variables for init if they exist

### DIFF
--- a/internal/fleek/config.go
+++ b/internal/fleek/config.go
@@ -205,7 +205,7 @@ func NewUser() (*User, error) {
 	}
 	envpubkey := os.Getenv("FLEEK_USER_PUBKEY")
 	envprivkey := os.Getenv("FLEEK_USER_PRIVKEY")
-	if (envpubkey == "") && (envpubkey == "") {
+	if (envpubkey == "") && (envprivkey == "") {
 
 		// ssh keys
 		privateKey := ""

--- a/internal/fleek/config.go
+++ b/internal/fleek/config.go
@@ -205,7 +205,7 @@ func NewUser() (*User, error) {
 	}
 	envpubkey := os.Getenv("FLEEK_USER_PUBKEY")
 	envprivkey := os.Getenv("FLEEK_USER_PRIVKEY")
-	if envpubkey == "" && envpubkey == "" {
+	if (envpubkey == "") && (envpubkey == "") {
 
 		// ssh keys
 		privateKey := ""


### PR DESCRIPTION
checks `FLEEK_USER_EMAIL`, `FLEEK_USER_NAME`, `FLEEK_USER_PUBKEY`, `FLEEK_USER_PRIVKEY` and uses them for current user's info on `fleek init`, making the init process non-interactive if at least NAME and EMAIL are set.