### PR TITLE
fix: unique arch-os combo in flake.nix

### DIFF
--- a/internal/flake/templates/flake.nix.tmpl
+++ b/internal/flake/templates/flake.nix.tmpl
@@ -22,8 +22,8 @@
   };
 
   outputs = { self, nixpkgs, home-manager, fleek, ... }@inputs: {
-    {{ range .Config.Systems }}
-     packages.{{ .Arch }}-{{ .OS }}.fleek = fleek.packages.{{ .Arch }}-{{ .OS }}.default;
+    {{ range .Config.UniqueSystems }}
+     packages.{{ . }}.fleek = fleek.packages.{{ . }}.default;
     {{ end }}
     # Available through 'home-manager --flake .#your-username@your-hostname'
     {{ $overlays := .Config.Overlays  }}

--- a/internal/fleek/config.go
+++ b/internal/fleek/config.go
@@ -310,6 +310,22 @@ func isValueInList(value string, list []string) bool {
 	return false
 }
 
+func (c *Config) UniqueSystems() []string {
+	var m = make(map[string]bool)
+	var systems = []string{}
+
+	for _, sys := range c.Systems {
+		syskey := sys.Arch + "-" + sys.OS
+		if m[syskey] {
+			continue
+		}
+		systems = append(systems, syskey)
+		m[syskey] = true
+	}
+	return systems
+
+}
+
 func (c *Config) UserFlakeDir() string {
 	home, _ := os.UserHomeDir()
 	// if for some reason the flakedir key is


### PR DESCRIPTION
fixes a bug where the fleek binary would be added to the flake output multiple times if you had more than one system in your config with the same arch/os combo.