### PR TITLE
feat: Enable shared system definitons with host name override

### DIFF
--- a/internal/fleek/system.go
+++ b/internal/fleek/system.go
@@ -57,6 +57,10 @@ func Name() (string, error) {
 }
 
 func Hostname() (string, error) {
+	override := os.Getenv("FLEEK_HOST_OVERRIDE")
+	if override != "" {
+		return override, nil
+	}
 	h, e := os.Hostname()
 	if e != nil {
 		return "", e


### PR DESCRIPTION
Fleek will now use the value of `FLEEK_HOST_OVERRIDE` as the hostname when calculating which flake to apply to the current system.

This allows you to have a single shared definitions for ephemeral machines that all share the same attributes (OS/architecture), for example in automated development environments.

Set `FLEEK_HOST_OVERRIDE` to the name of the system definition you wish to declare/use before running Fleek.

```
export FLEEK_HOST_OVERRIDE=ubuntuvm
fleek join git@github.com:YOU/fleek
```