### PR TITLE
feat: remove apply flag from add,join,remove,update

### DIFF
--- a/internal/fleekcli/add.go
+++ b/internal/fleekcli/add.go
@@ -11,12 +11,7 @@ import (
 	"github.com/ublue-os/fleek/internal/flake"
 )
 
-type addCmdFlags struct {
-	apply bool
-}
-
 func AddCommand() *cobra.Command {
-	flags := addCmdFlags{}
 	command := &cobra.Command{
 		Use:     app.Trans("add.use"),
 		Short:   app.Trans("add.short"),
@@ -27,9 +22,6 @@ func AddCommand() *cobra.Command {
 			return add(cmd, args)
 		},
 	}
-	command.Flags().BoolVarP(
-		&flags.apply, app.Trans("add.applyFlag"), "a", false, app.Trans("add.applyFlagDescription"))
-
 	return command
 }
 
@@ -40,10 +32,6 @@ func add(cmd *cobra.Command, args []string) error {
 	err := mustConfig()
 	if err != nil {
 		return err
-	}
-	var apply bool
-	if cmd.Flag(app.Trans("add.applyFlag")).Changed {
-		apply = true
 	}
 
 	fl, err := flake.Load(cfg, app)
@@ -124,19 +112,16 @@ func add(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if apply {
-		fin.Info.Println(app.Trans("add.applying"))
+	fin.Info.Println(app.Trans("add.applying"))
 
-		err = fl.Apply()
-		if err != nil {
-			if errors.Is(err, flake.ErrPackageConflict) {
-				fin.Fatal.Println(app.Trans("global.errConflict"))
-			}
-			return err
+	err = fl.Apply()
+	if err != nil {
+		if errors.Is(err, flake.ErrPackageConflict) {
+			fin.Fatal.Println(app.Trans("global.errConflict"))
 		}
-	} else {
-		fin.Warning.Println(app.Trans("add.unapplied"))
+		return err
 	}
+
 	fin.Success.Println(app.Trans("global.completed"))
 	return nil
 }

--- a/internal/fleekcli/join.go
+++ b/internal/fleekcli/join.go
@@ -16,12 +16,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type joinCmdFlags struct {
-	apply bool
-}
-
 func JoinCommand() *cobra.Command {
-	flags := joinCmdFlags{}
 	command := &cobra.Command{
 		Use:     app.Trans("join.use"),
 		Short:   app.Trans("join.short"),
@@ -32,8 +27,6 @@ func JoinCommand() *cobra.Command {
 			return join(cmd, args)
 		},
 	}
-	command.Flags().BoolVarP(
-		&flags.apply, app.Trans("join.applyFlag"), "a", false, app.Trans("join.applyFlagDescription"))
 	return command
 }
 
@@ -94,12 +87,9 @@ func join(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if cmd.Flag(app.Trans("join.applyFlag")).Changed {
-		err = fl.Apply()
-		if err != nil {
-			return err
-		}
-		return nil
+	err = fl.Apply()
+	if err != nil {
+		return err
 	}
 	fin.Info.Println(app.Trans("join.complete"))
 


### PR DESCRIPTION
Removes the annoying `apply` step from `fleek {add | join | remove | update}`.

Leaves the `apply` step in `fleek init` for now.