### PR TITLE
fix: bad parens on logger

### DIFF
--- a/internal/flake/flake.go
+++ b/internal/flake/flake.go
@@ -114,7 +114,7 @@ func (f *Flake) Create(force bool, symlink bool) error {
 		return err
 	}
 
-	fin.Logger.Info("", fin.Logger.Args(f.app.Trans("init.blingLevel", f.Config.Bling)))
+	fin.Logger.Info("", fin.Logger.Args(f.app.Trans("init.blingLevel"), f.Config.Bling))
 	err = f.Config.WriteInitialConfig(force, symlink)
 	if err != nil {
 		return err


### PR DESCRIPTION
fix bad parens location on logger